### PR TITLE
Fix edge case: negative number in task text

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -380,7 +380,7 @@ void renderInfo() {
   if (playersCount == 1) {
     extern int GAME_WIN_NUM;
     char buf[1<<8];
-    sprintf(buf, "Find %d more heros!", GAME_WIN_NUM - spriteSnake[0]->num);
+    sprintf(buf, "Find %d more heros!", GAME_WIN_NUM > spriteSnake[0]->num ? GAME_WIN_NUM - spriteSnake[0]->num : 0);
     setText(taskText, buf);
     renderText(taskText, startX, startY, 1);
     startY += lineGap;


### PR DESCRIPTION
# Bug description:
When the length of the snake exceeds the GAME_WIN_NUM, the screen shows negative number of heroes to find. 

# Steps to reproduce:
### When your snake length equals to GAME_WIN_NUM - 1
![before eating](https://user-images.githubusercontent.com/8069472/75964824-75d5c400-5efa-11ea-9492-3ccf1c6aed21.jpg)
### Two or more heroes join the snake at nearly same time
![image333](https://user-images.githubusercontent.com/8069472/75964850-7cfcd200-5efa-11ea-97f9-d2935b2d13b9.jpg)

# Fix
Never show negative number in task text, show zero whenever it reaches the GAME_WIN_NUM.
