### PR TITLE
Rename binary to dungeon_rush

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ snake
 *.zip
 storage.dat
 archive
+dungeon_rush

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ OBJS = src/*.c
 CC = gcc
 LINKER_FLAGS = -lSDL2 -lSDL2_image -lSDL2_ttf -lSDL2_mixer -lm
 CFLAGS = -g -Wall
-OBJ_NAME = snake
+OBJ_NAME = dungeon_rush
 
-snake: $(OBJS) src/*.h
+dungeon_rush: $(OBJS) src/*.h
 	$(CC) $(OBJS) $(LINKER_FLAGS) $(CFLAGS) -o $(OBJ_NAME) -DDBG
 	echo 1 0 0 0 0 0 > storage.dat
 dist_bin: $(OBJS) src/*.h
@@ -17,8 +17,8 @@ dist_linux: dist_bin
 	cp storage.dat dist/linux
 	zip -r dist/DungeonRush_linux.zip dist/linux
 zip:
-	zip -r snake`date -I` *.c *.h Makefile res *.dat
-	cp snake`date -I`.zip ~/Downloads
+	zip -r dungeon_rush`date -I` *.c *.h Makefile res *.dat
+	cp dungeon_rush`date -I`.zip ~/Downloads
 	mv *.zip archive
-run: snake
-	./snake
+run: dungeon_rush
+	./dungeon_rush


### PR DESCRIPTION
Lets rename the binary to dungeon_rush since `snake` is a rather generic name.
This way there is less chance to have duplicate name if this ever get's packaged for a Linux distribution.