### PR TITLE
docs: fix simple typo, shuold -> should

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -39,7 +39,7 @@ void destroyGame(int);
 int gameLoop();
 void updateAnimationOfSprite(Sprite* self);
 void updateAnimationOfBlock(Block* self);
-// this shuold only be used to create once or permant animation
+// this should only be used to create once or permant animation
 Animation* createAndPushAnimation(LinkList* list, Texture* texture,
                                   const Effect* effect, LoopType lp,
                                   int duration, int x, int y,


### PR DESCRIPTION
There is a small typo in src/game.h.

Should read `should` rather than `shuold`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md